### PR TITLE
Allow pki.credentials to be async

### DIFF
--- a/carthage_base/proxy.py
+++ b/carthage_base/proxy.py
@@ -16,7 +16,7 @@ import carthage.dns
 import carthage.pki
 from carthage import *
 from carthage.modeling import *
-from carthage.utils import memoproperty
+from carthage.utils import memoproperty, possibly_async
 from carthage.modeling.utils import setattr_default # xxx this should move somewhere more public
 from carthage.oci import *
 from carthage.podman import *
@@ -244,7 +244,8 @@ class PkiCertRole(ImageRole, AsyncInjectable):
             for d in self.model.pki_manager_domains:
                 domain_path = pki_path/d
                 if domain_path.exists(): continue
-                domain_path.write_text(self.pki.credentials(d))
+                c = await possibly_async(self.pki.credentials(d))
+                domain_path.write_text(c)
                 
 __all__ += ['PkiCertRole']
 


### PR DESCRIPTION
This is so that I can implement a PkiManager that gets certificates lazily and async