### PR TITLE
Catch invalid str entries for dns_servers

### DIFF
--- a/carthage_base/templates/dhcp-dnsmasq.conf
+++ b/carthage_base/templates/dhcp-dnsmasq.conf
@@ -18,6 +18,10 @@ domain=${d.replace('~','')}
 local=/${d.replace('~','')}/
 %endif
 %endfor
+<%
+if isinstance(link.merged_v4_config.dns_servers, str):
+    raise RuntimeError(f"dns_servers should be a sequence, not a string")
+%>
 %for server in link.merged_v4_config.dns_servers:
 server=${server}
 %endfor


### PR DESCRIPTION
Accidentally providing a str for dns_servers results in silently getting a dnsmasq config consisting of something like

server=1
server=9
server=2

..etc, which is pretty undesirable.